### PR TITLE
MULE-8831 compiled expressions setters support method overloading

### DIFF
--- a/src/main/java/org/mule/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
+++ b/src/main/java/org/mule/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
@@ -54,6 +54,14 @@ public class MethodAccessor implements AccessorNode {
           if (o != null) {
             return executeOverrideTarget(getWidenedTarget(o), ctx, elCtx, vars);
           }
+          else {
+            if (parms != null) {
+              o = getBestCandidate(argTypes(elCtx, vars), method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+              if (o != null) {
+                return executeOverrideTarget(getWidenedTarget(o), ctx, elCtx, vars);
+              }
+            }
+          }
         }
 
         coercionNeeded = true;
@@ -130,6 +138,18 @@ public class MethodAccessor implements AccessorNode {
             "actual target: " + ctx.getClass().getName() + "::" + method.getName() + "; coercionNeeded=" + (coercionNeeded ? "yes" : "no") + ")");
       }
     }
+  }
+
+  private Class[] argTypes(Object ctx, VariableResolverFactory vars) {
+    if (parms.length == 0)
+      return new Class[0];
+
+    Class[] vals = new Class[parms.length];
+    for (int i = 0; i < parms.length; i++) {
+      vals[i] = parms[i].getValue(ctx, vars).getClass();
+    }
+
+    return vals;
   }
 
   private Object[] executeAll(Object ctx, VariableResolverFactory vars, Method m) {


### PR DESCRIPTION
Results for performance tests on assignment scenarios that use this changed code (see PR in mule project that includes the tests):

|      | Before | | | After | | | Var   | | |
|------|--------|---------|--------|-------|-------|-------|-------|-------|-------|
|      | max    | avg     | med    | max   | avg   | med   | max   | avg   | med   |
| Cold | 2694   | 2569.75 | 2539   | 2742  | 2677  | 2659  | +1.8% | +4.2% | +4.7% |
| Warm | 4      | 1.20    | 1      | 4     | 1.25  | 1     | =     | +4%   | =     |
| Hot  | 3      | 1.20    | 1      | 3     | 1.20  | 1     | =     | =     |       |