### PR TITLE
MULE-9340: MEL/MVEL incapable of evaluating Number against empty

### DIFF
--- a/src/main/java/org/mule/mvel2/math/MathProcessor.java
+++ b/src/main/java/org/mule/mvel2/math/MathProcessor.java
@@ -20,6 +20,7 @@ package org.mule.mvel2.math;
 import org.mule.mvel2.DataTypes;
 import org.mule.mvel2.Operator;
 import org.mule.mvel2.Unit;
+import org.mule.mvel2.compiler.BlankLiteral;
 import org.mule.mvel2.debug.DebugTools;
 import org.mule.mvel2.util.InternalNumber;
 
@@ -664,7 +665,7 @@ public strictfp class MathProcessor {
   }
 
   private static Double getNumber(Object in, int type) {
-    if (in == null)
+    if (in == null || in == BlankLiteral.INSTANCE)
       return 0d;
     switch (type) {
       case BIG_DECIMAL:

--- a/src/test/java/org/mule/mvel2/tests/core/ComparisonTests.java
+++ b/src/test/java/org/mule/mvel2/tests/core/ComparisonTests.java
@@ -151,6 +151,14 @@ public class ComparisonTests extends AbstractTest {
     assertEquals(false, _test("empty == ['a']"));
   }
 
+  public void testBlank11() {
+    assertEquals(false, _test("1 == empty"));
+  }
+
+  public void testBlank12() {
+    assertEquals(true, _test("0 == empty"));
+  }
+
   public void testInstanceCheck1() {
     assertEquals(true, test("c is java.lang.String"));
   }


### PR DESCRIPTION
This PR contains a fix to allow evaluating numeric objects against empty.