### PR TITLE
MULE-9595: MEL cached expression with null safe property is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 .settings/org.eclipse.jdt.core.prefs
 mvel_ser_test*
+/.settings/*
+/.classpath
+/.project

--- a/src/main/java/org/mule/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mule/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -757,8 +757,13 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
       }
 
       if (ctx != null && MVEL.COMPILER_OPT_PROPERTY_ACCESS_DOESNT_FAIL ||
-          ctx == null && nullSafe) {
-        addAccessorNode(new NullAccessor());
+        ctx == null && nullSafe) {
+        if (currNode instanceof NullSafe) {
+          nullSafe = true;
+        }
+        else {
+          addAccessorNode(new NullAccessor());
+        }
         return null;
       }
 

--- a/src/test/java/org/mule/mvel2/tests/core/PropertyAccessTests.java
+++ b/src/test/java/org/mule/mvel2/tests/core/PropertyAccessTests.java
@@ -573,4 +573,19 @@ public class PropertyAccessTests extends AbstractTest {
   public void testPublicStaticFieldMVEL314(){
     assertEquals(Foo.STATIC_BAR, runSingleTest("org.mule.mvel2.tests.core.res.Foo.STATIC_BAR"));
   }
+
+  public void testExpressionCacheAfterMissingOptionalProperty() {
+    MVEL.COMPILER_OPT_PROPERTY_ACCESS_DOESNT_FAIL = true;
+    Map a = new HashMap<String, Object>();
+    Map m = Collections.singletonMap("a", a);
+    Map<String, Object> nestMap = Collections.<String, Object> singletonMap("foo", "bar");
+    String ex = "a.?inner.foo";
+    Serializable s;
+
+    s = MVEL.compileExpression(ex);
+    a.put("inner", "");
+    assertNull(MVEL.executeExpression(s, m));
+    a.put("inner", nestMap);
+    assertEquals("bar", MVEL.executeExpression(s, m));
+  }
 }


### PR DESCRIPTION
after returning null