### PR TITLE
MULE-17002: Illegal type in constant pool when using more than 51 global function elements inside XML

### DIFF
--- a/src/main/java/org/mule/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mule/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -85,7 +85,7 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
       OPCODES_VERSION = Opcodes.V1_4;
     else if (javaVersion.startsWith("1.5"))
       OPCODES_VERSION = Opcodes.V1_5;
-    else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7"))
+    else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8"))
       OPCODES_VERSION = Opcodes.V1_6;
     else
       OPCODES_VERSION = Opcodes.V1_2;

--- a/src/main/java/org/mule/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mule/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -85,7 +85,13 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
       OPCODES_VERSION = Opcodes.V1_4;
     else if (javaVersion.startsWith("1.5"))
       OPCODES_VERSION = Opcodes.V1_5;
-    else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8"))
+    else if (javaVersion.startsWith("1.6")
+          || javaVersion.startsWith("1.7")
+          || javaVersion.startsWith("1.8")
+          || javaVersion.startsWith("9")
+          || javaVersion.startsWith("10")
+          || javaVersion.startsWith("11")
+          || javaVersion.startsWith("12"))
       OPCODES_VERSION = Opcodes.V1_6;
     else
       OPCODES_VERSION = Opcodes.V1_2;


### PR DESCRIPTION
function elements inside XML

Description:
In Studio version 6.6.0, converting XML payload into Java, the previous
is failing when using more than 51 elements with "generateUUID()"
function.
The problem is in the ASMAccessorOptimizer class. Since for Java version
1.8 it uses an incorrect OPCODES_VERSION.

Proposed Solution:
Modification of the ASMAccessorOptimizer class so that the correct
OPCODES_VERSION is used.

This implementation is already done in the mvel upstream repository.
